### PR TITLE
feature: enhance destroy command

### DIFF
--- a/spec/executor.go
+++ b/spec/executor.go
@@ -64,6 +64,8 @@ func (exp *ExpModel) GetFlags() string {
 	return strings.Join(flags, " ")
 }
 
+const UnknownUid = "unknown"
+
 func SetDestroyFlag(ctx context.Context, suid string) context.Context {
 	return context.WithValue(ctx, DestroyKey, suid)
 }

--- a/spec/model.go
+++ b/spec/model.go
@@ -76,10 +76,16 @@ type ExpActionCommandSpec interface {
 }
 
 type ExpFlagSpec interface {
+	// FlagName returns the flag FlagName
 	FlagName() string
+	// FlagDesc returns the flag description
 	FlagDesc() string
+	// FlagNoArgs returns true if the flag is bool type
 	FlagNoArgs() bool
+	// FlagRequired returns true if the flag is necessary when creating experiment
 	FlagRequired() bool
+	// FlagRequiredWhenDestroyed returns true if the flag is necessary when destroying experiment
+	FlagRequiredWhenDestroyed() bool
 }
 
 // ExpFlag defines the action flag
@@ -95,6 +101,8 @@ type ExpFlag struct {
 
 	// Required means necessary or not
 	Required bool `yaml:"required"`
+	// RequiredWhenDestroyed is true if the flag is necessary when destroying experiment
+	RequiredWhenDestroyed bool `yaml:"requiredWhenDestroyed"`
 }
 
 func (f *ExpFlag) FlagName() string {
@@ -111,6 +119,10 @@ func (f *ExpFlag) FlagNoArgs() bool {
 
 func (f *ExpFlag) FlagRequired() bool {
 	return f.Required
+}
+
+func (f *ExpFlag) FlagRequiredWhenDestroyed() bool {
+	return f.RequiredWhenDestroyed
 }
 
 // BaseExpModelCommandSpec defines the common struct of the implementation of ExpModelCommandSpec

--- a/util/spec.go
+++ b/util/spec.go
@@ -91,10 +91,11 @@ func ConvertSpecToModels(commandSpec spec.ExpModelCommandSpec, prepare spec.ExpP
 				matchers := make([]spec.ExpFlag, 0)
 				for _, m := range action.Matchers() {
 					matchers = append(matchers, spec.ExpFlag{
-						Name:     m.FlagName(),
-						Desc:     m.FlagDesc(),
-						NoArgs:   m.FlagNoArgs(),
-						Required: m.FlagRequired(),
+						Name:                  m.FlagName(),
+						Desc:                  m.FlagDesc(),
+						NoArgs:                m.FlagNoArgs(),
+						Required:              m.FlagRequired(),
+						RequiredWhenDestroyed: m.FlagRequiredWhenDestroyed(),
 					})
 				}
 				return matchers
@@ -103,25 +104,28 @@ func ConvertSpecToModels(commandSpec spec.ExpModelCommandSpec, prepare spec.ExpP
 				flags := make([]spec.ExpFlag, 0)
 				for _, m := range action.Flags() {
 					flags = append(flags, spec.ExpFlag{
-						Name:     m.FlagName(),
-						Desc:     m.FlagDesc(),
-						NoArgs:   m.FlagNoArgs(),
-						Required: m.FlagRequired(),
+						Name:                  m.FlagName(),
+						Desc:                  m.FlagDesc(),
+						NoArgs:                m.FlagNoArgs(),
+						Required:              m.FlagRequired(),
+						RequiredWhenDestroyed: m.FlagRequiredWhenDestroyed(),
 					})
 				}
 				for _, m := range commandSpec.Flags() {
 					flags = append(flags, spec.ExpFlag{
-						Name:     m.FlagName(),
-						Desc:     m.FlagDesc(),
-						NoArgs:   m.FlagNoArgs(),
-						Required: m.FlagRequired(),
+						Name:                  m.FlagName(),
+						Desc:                  m.FlagDesc(),
+						NoArgs:                m.FlagNoArgs(),
+						Required:              m.FlagRequired(),
+						RequiredWhenDestroyed: m.FlagRequiredWhenDestroyed(),
 					})
 				}
 				flags = append(flags,
 					spec.ExpFlag{
-						Name:     "timeout",
-						Desc:     "set timeout for experiment",
-						Required: false,
+						Name:                  "timeout",
+						Desc:                  "set timeout for experiment",
+						Required:              false,
+						RequiredWhenDestroyed: false,
 					},
 				)
 				return flags

--- a/util/util.go
+++ b/util/util.go
@@ -32,6 +32,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 var proPath string
@@ -129,6 +131,7 @@ func GetSpecifyingUserHome(username string) string {
 
 // Curl url
 func Curl(url string) (string, error, int) {
+	logrus.Infoln(url)
 	trans := http.Transport{
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return net.DialTimeout(network, addr, 10*time.Second)


### PR DESCRIPTION
See chaosblade-io/chaosblade#239 for the details.

## Describe how you did it
1. Add `requiredWhenDestroyed` field which marks the necessary flag when destroying with target and action parameters in flag spec.

2. Use the suid value in the context to determine which way to execute destroy, if execute destroy command with target and action parameters, the suid value is unknown, otherwise is the experiment uid.