### PR TITLE
bugfix: resolve too many process bugs when running jvm environmnet pr…

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -111,7 +111,7 @@ func GetPidsByProcessName(processName string, ctx context.Context) ([]string, er
 		}
 	}
 	response := Run(ctx, "ps",
-		fmt.Sprintf(`%s | grep "%s" %s %s | grep -v -w grep | grep -v -w chaos_killprocess | grep -v -w chaos_stopprocess | awk '{print $2}' | tr '\n' ' '`,
+		fmt.Sprintf(`%s | grep "%s" %s %s | grep -v -w grep | grep -v -w chaosblade| grep -v -w chaos_killprocess | grep -v -w chaos_stopprocess | awk '{print $2}' | tr '\n' ' '`,
 			psArgs, processName, otherGrepInfo, excludeGrepInfo))
 	if !response.Success {
 		return nil, fmt.Errorf(response.Err)

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -111,7 +111,7 @@ func GetPidsByProcessName(processName string, ctx context.Context) ([]string, er
 		}
 	}
 	response := Run(ctx, "ps",
-		fmt.Sprintf(`%s | grep "%s" %s %s | grep -v -w grep | grep -v -w chaosblade| grep -v -w chaos_killprocess | grep -v -w chaos_stopprocess | awk '{print $2}' | tr '\n' ' '`,
+		fmt.Sprintf(`%s | grep "%s" %s %s | grep -v -w grep | grep -v -w blade| grep -v -w chaos_killprocess | grep -v -w chaos_stopprocess | awk '{print $2}' | tr '\n' ' '`,
 			psArgs, processName, otherGrepInfo, excludeGrepInfo))
 	if !response.Success {
 		return nil, fmt.Errorf(response.Err)


### PR DESCRIPTION
…epare command via http api

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->
  https://github.com/chaosblade-io/chaosblade-spec-go/issues/6
### Describe what this PR does / why we need it

   It resolved the too many process bug when calling prepare command with javaHome and process flags passed
### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
   Fixes #6
### Describe how you did it
   
      When finding the pids of the process by process name, filter out chaosblade's own command, then the pid number will be 1

### Describe how to verify it

      calling the prepare api with javaHome flag and it's value has java key word,
   e.g: curl   "hostname:9526/chaosblade?cmd=prepare%20jvm%20--javaHome=/home/q/java/default%20--process=pf_noah_web_ui"
   it will return too many process
### Special notes for reviews
