### PR TITLE
feat: add CUSTOM type to support custom log path

### DIFF
--- a/util/log.go
+++ b/util/log.go
@@ -29,17 +29,23 @@ import (
 const (
 	Blade = 1
 	Bin   = 2
+	Custom= 3
 )
 
 const BladeLog = "chaosblade.log"
 
 var (
 	Debug    bool
+	LogPath  string
 	LogLevel string
 )
 
 func AddDebugFlag() {
 	flag.BoolVar(&Debug, "debug", false, "set debug mode")
+}
+
+func AddLogPathFlag() {
+	flag.StringVar(&LogPath, "log-path", GetProgramPath(), "the directory path to save chaosblade.log.")
 }
 
 func AddLogLevelFlag() {
@@ -127,6 +133,8 @@ func GetLogPath(programType int) (string, error) {
 		binDir = GetProgramPath()
 	case Bin:
 		binDir = GetProgramParentPath()
+	case Custom:
+		binDir = LogPath
 	default:
 		binDir = GetProgramPath()
 	}


### PR DESCRIPTION

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
add CUSTOM type to support custom log path set by log-path flag, conveniently saving the log file in custom path, for the logs persistence scene. It will be used in chaosblade cli by log-path flag.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
