### PR TITLE
feature: add self-verify type and self-verify failed code type

### DIFF
--- a/spec/constants.go
+++ b/spec/constants.go
@@ -6,6 +6,7 @@ const (
 	ChaosOsBin        = "chaos_os"
 	Destroy           = "destroy"
 	Create            = "create"
+	Verify            = "verify"
 	True              = "true"
 	False             = "false"
 	BinPath           = "bin"

--- a/spec/executor.go
+++ b/spec/executor.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	DestroyKey = "suid"
+	DestroyKey = "destroy"
+	VerifyKey  = "verify"
 )
 
 // ExpModel is the experiment data object
@@ -46,7 +47,7 @@ type ExpModel struct {
 	// Categories
 	ActionCategories []string `json:"categories,omitempty"`
 
-	ActionProcessHang bool     `yaml:"actionProcessHang"`
+	ActionProcessHang bool `yaml:"actionProcessHang"`
 }
 
 // ExpExecutor defines the ExpExecutor interface
@@ -78,9 +79,22 @@ func SetDestroyFlag(ctx context.Context, suid string) context.Context {
 	return context.WithValue(ctx, DestroyKey, suid)
 }
 
+func SetVerifyFlag(ctx context.Context, suid string) context.Context {
+	return context.WithValue(ctx, VerifyKey, suid)
+}
+
 // IsDestroy command
 func IsDestroy(ctx context.Context) (string, bool) {
 	suid := ctx.Value(DestroyKey)
+	if suid == nil {
+		return "", false
+	}
+	return suid.(string), true
+}
+
+// IsVerify command
+func IsVerify(ctx context.Context) (string, bool) {
+	suid := ctx.Value(VerifyKey)
 	if suid == nil {
 		return "", false
 	}

--- a/spec/response.go
+++ b/spec/response.go
@@ -117,6 +117,10 @@ var (
 	SystemdNotFound                   = CodeType{66001, "`%s`: systemd not found, err: %v"}
 	DatabaseError                     = CodeType{67001, "`%s`: failed to execute, err: %v"}
 	DataNotFound                      = CodeType{67002, "`%s` record not found, if it's k8s experiment, please add --target k8s flag to retry"}
+	PingSelfVerifyFailed              = CodeType{68001, "`%s` experiment self-verify by ping failed, expected number is %s, actual number is %s"}
+	DnsSelfVerifyFailed               = CodeType{68002, "dns experiment self-verify failed, --domain `%s` --ip `%s`"}
+	OccupySelfVerifyFailed            = CodeType{68003, "occupy experiment self-verify failed, --port `%s`"}
+	TcpClientInitFailed               = CodeType{68004, "tcp client init failed, err %v"}
 )
 
 func (c CodeType) Sprintf(values ...interface{}) string {


### PR DESCRIPTION
PR: 
1. add new verify type to ctx value, and mod Destroy key to "destroy" from "suid"
2. add self-verify (dns,occupy) (ping of network tc) command failed code type