### PR TITLE
chore: add scripts and Makefile targets to verify and reformat go codes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,5 @@ jobs:
       - name: Run vet
         run: go vet ./...
 
-        
+      - name: Run code style and import order verification
+        run: make verify

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: help format verify
+
+help:
+	@echo "Available make targets:"
+	@echo "  format   Run update-gofmt.sh and update-imports.sh to automatically fix Go code formatting and import order."
+	@echo "  verify   Run verify-gofmt.sh and verify-imports.sh to check Go code formatting and import order."
+	@echo "  help     Show this help message."
+
+format:
+	@echo "Running goimports and gofumpt to format Go code..."
+	@./hack/update-imports.sh
+	@./hack/update-gofmt.sh
+
+verify:
+	@echo "Verifying Go code formatting and import order..."
+	@./hack/verify-gofmt.sh
+	@./hack/verify-imports.sh
+

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -29,9 +29,11 @@ import (
 )
 
 // grep ${key}
-const ProcessKey = "process"
-const ExcludeProcessKey = "excludeProcess"
-const ProcessCommandKey = "processCommand"
+const (
+	ProcessKey        = "process"
+	ExcludeProcessKey = "excludeProcess"
+	ProcessCommandKey = "processCommand"
+)
 
 func GetPidsByLocalPort(ctx context.Context, channel spec.Channel, localPort string) ([]string, error) {
 	available := channel.IsCommandAvailable(ctx, "ss")

--- a/channel/local_mock.go
+++ b/channel/local_mock.go
@@ -53,7 +53,7 @@ func NewMockLocalChannel() spec.Channel {
 	}
 }
 
-func (l *MockLocalChannel) Name() string  {
+func (l *MockLocalChannel) Name() string {
 	return "mock"
 }
 
@@ -72,6 +72,7 @@ func (mlc *MockLocalChannel) GetPsArgs(ctx context.Context) string {
 func (mlc *MockLocalChannel) IsAlpinePlatform(ctx context.Context) bool {
 	return false
 }
+
 func (mlc *MockLocalChannel) IsAllCommandsAvailable(ctx context.Context, commandNames []string) (*spec.Response, bool) {
 	return nil, false
 }
@@ -107,27 +108,35 @@ func (mlc *MockLocalChannel) GetScriptPath() string {
 var defaultGetPidsByProcessCmdNameFunc = func(processName string, ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
+
 var defaultGetPidsByProcessNameFunc = func(processName string, ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }
+
 var defaultGetPsArgsFunc = func(ctx context.Context) string {
 	return "-eo user,pid,ppid,args"
 }
+
 var defaultIsCommandAvailableFunc = func(ctx context.Context, commandName string) bool {
 	return false
 }
+
 var defaultProcessExistsFunc = func(pid string) (bool, error) {
 	return false, nil
 }
+
 var defaultGetPidUserFunc = func(pid string) (string, error) {
 	return "admin", nil
 }
+
 var defaultGetPidsByLocalPortsFunc = func(ctx context.Context, localPorts []string) ([]string, error) {
 	return []string{}, nil
 }
+
 var defaultGetPidsByLocalPortFunc = func(ctx context.Context, localPort string) ([]string, error) {
 	return []string{}, nil
 }
+
 var defaultRunFunc = func(ctx context.Context, script, args string) *spec.Response {
 	return spec.ReturnSuccess("success")
 }

--- a/channel/local_unixs.go
+++ b/channel/local_unixs.go
@@ -28,14 +28,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shirou/gopsutil/process"
+
 	"github.com/chaosblade-io/chaosblade-spec-go/log"
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 	"github.com/chaosblade-io/chaosblade-spec-go/util"
-	"github.com/shirou/gopsutil/process"
 )
 
-type LocalChannel struct {
-}
+type LocalChannel struct{}
 
 // NewLocalChannel returns a local channel for invoking the host command
 func NewLocalChannel() spec.Channel {
@@ -182,7 +182,7 @@ func getExcludeProcesses(ctx context.Context) []string {
 }
 
 func (l *LocalChannel) GetPsArgs(ctx context.Context) string {
-	var psArgs = "-eo user,pid,ppid,args"
+	psArgs := "-eo user,pid,ppid,args"
 	if l.IsAlpinePlatform(ctx) {
 		psArgs = "-o user,pid,ppid,args"
 	}
@@ -190,7 +190,7 @@ func (l *LocalChannel) GetPsArgs(ctx context.Context) string {
 }
 
 func (l *LocalChannel) IsAlpinePlatform(ctx context.Context) bool {
-	var osVer = ""
+	osVer := ""
 	if util.IsExist("/etc/os-release") {
 		response := l.Run(ctx, "awk", "-F '=' '{if ($1 == \"ID\") {print $2;exit 0}}' /etc/os-release")
 		if response.Success {
@@ -236,7 +236,7 @@ func (l *LocalChannel) GetPidsByLocalPorts(ctx context.Context, localPorts []str
 	if len(localPorts) == 0 {
 		return nil, fmt.Errorf("the local port parameter is empty")
 	}
-	var result = make([]string, 0)
+	result := make([]string, 0)
 	for _, port := range localPorts {
 		pids, err := l.GetPidsByLocalPort(ctx, port)
 		if err != nil {

--- a/channel/local_windows.go
+++ b/channel/local_windows.go
@@ -28,14 +28,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shirou/gopsutil/process"
+
 	"github.com/chaosblade-io/chaosblade-spec-go/log"
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 	"github.com/chaosblade-io/chaosblade-spec-go/util"
-	"github.com/shirou/gopsutil/process"
 )
 
-type LocalChannel struct {
-}
+type LocalChannel struct{}
 
 // NewLocalChannel returns a local channel for invoking the host command
 func NewLocalChannel() spec.Channel {
@@ -182,7 +182,7 @@ func getExcludeProcesses(ctx context.Context) []string {
 }
 
 func (l *LocalChannel) GetPsArgs(ctx context.Context) string {
-	var psArgs = "-eo user,pid,ppid,args"
+	psArgs := "-eo user,pid,ppid,args"
 	if l.IsAlpinePlatform(ctx) {
 		psArgs = "-o user,pid,ppid,args"
 	}
@@ -190,7 +190,7 @@ func (l *LocalChannel) GetPsArgs(ctx context.Context) string {
 }
 
 func (l *LocalChannel) IsAlpinePlatform(ctx context.Context) bool {
-	var osVer = ""
+	osVer := ""
 	if util.IsExist("/etc/os-release") {
 		response := l.Run(ctx, "awk", "-F '=' '{if ($1 == \"ID\") {print $2;exit 0}}' /etc/os-release")
 		if response.Success {
@@ -236,7 +236,7 @@ func (l *LocalChannel) GetPidsByLocalPorts(ctx context.Context, localPorts []str
 	if localPorts == nil || len(localPorts) == 0 {
 		return nil, fmt.Errorf("the local port parameter is empty")
 	}
-	var result = make([]string, 0)
+	result := make([]string, 0)
 	for _, port := range localPorts {
 		pids, err := l.GetPidsByLocalPort(ctx, port)
 		if err != nil {

--- a/channel/nsexec.go
+++ b/channel/nsexec.go
@@ -186,7 +186,7 @@ func (l *NSExecChannel) IsCommandAvailable(ctx context.Context, commandName stri
 }
 
 func (l *NSExecChannel) GetPsArgs(ctx context.Context) string {
-	var psArgs = "-eo user,pid,ppid,args"
+	psArgs := "-eo user,pid,ppid,args"
 	if l.IsAlpinePlatform(ctx) {
 		psArgs = "-o user,pid,ppid,args"
 	}
@@ -194,7 +194,7 @@ func (l *NSExecChannel) GetPsArgs(ctx context.Context) string {
 }
 
 func (l *NSExecChannel) IsAlpinePlatform(ctx context.Context) bool {
-	var osVer = ""
+	osVer := ""
 	if util.IsExist("/etc/os-release") {
 		response := l.Run(ctx, "awk", "-F '=' '{if ($1 == \"ID\") {print $2;exit 0}}' /etc/os-release")
 		if response.Success {

--- a/hack/init.sh
+++ b/hack/init.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+function git_find() {
+    # Similar to find but faster and easier to understand.  We want to include
+    # modified and untracked files because this might be running against code
+    # which is not tracked by git yet.
+    git ls-files -cmo --exclude-standard \
+        ':!:vendor/*'        `# catches vendor/...` \
+        ':!:*/vendor/*'      `# catches any subdir/vendor/...` \
+        ':!:third_party/*'   `# catches third_party/...` \
+        ':!:*/third_party/*' `# catches third_party/...` \
+        ':!:*/testdata/*'    `# catches any subdir/testdata/...` \
+        ':(glob)**/*.go' \
+        "$@"
+}

--- a/hack/update-gofmt.sh
+++ b/hack/update-gofmt.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source "$(dirname "$0")/init.sh"
+go install mvdan.cc/gofumpt@latest
+
+# Serially process each file to avoid concurrent write issues
+for f in $(git_find); do
+  gofumpt -w "$f"
+done
+

--- a/hack/update-imports.sh
+++ b/hack/update-imports.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source "$(dirname "$0")/init.sh"
+go install golang.org/x/tools/cmd/goimports@latest
+
+# Serially process each file to avoid concurrent write issues
+for f in $(git_find); do
+  goimports -w -local github.com/chaosblade-io/chaosblade-spec-go -srcdir "$(dirname "$f")" "$f"
+done
+

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source "$(dirname "$0")/init.sh"
+go install mvdan.cc/gofumpt@latest
+
+# gofmt exits with non-zero exit code if it finds a problem unrelated to
+# formatting (e.g., a file does not parse correctly). Without "|| true" this
+# would have led to no useful error message from gofmt, because the script would
+# have failed before getting to the "echo" in the block below.
+diff=$(git_find | xargs gofumpt -d 2>&1) || true
+if [[ -n "${diff}" ]]; then
+  echo "${diff}" >&2
+  echo >&2
+  echo "Run ./hack/update-gofmt.sh" >&2
+  exit 1
+fi

--- a/hack/verify-imports.sh
+++ b/hack/verify-imports.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source "$(dirname "$0")/init.sh"
+go install golang.org/x/tools/cmd/goimports@latest
+
+diff=$(git_find | xargs goimports -l -local github.com/chaosblade-io/chaosblade-spec-go 2>&1) || true
+if [[ -n "${diff}" ]]; then
+  echo "The following files have incorrect import order. Please run ./hack/update-imports.sh to fix them:" >&2
+  echo "${diff}" >&2
+  exit 1
+fi

--- a/log/log.go
+++ b/log/log.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 	"github.com/sirupsen/logrus"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 )
 
 func Panicf(ctx context.Context, format string, a ...interface{}) {

--- a/spec/channel.go
+++ b/spec/channel.go
@@ -22,7 +22,6 @@ import (
 
 // Channel is an interface for command invocation
 type Channel interface {
-
 	// channel name unique
 	Name() string
 

--- a/spec/executor.go
+++ b/spec/executor.go
@@ -46,7 +46,7 @@ type ExpModel struct {
 	// Categories
 	ActionCategories []string `json:"categories,omitempty"`
 
-	ActionProcessHang bool     `yaml:"actionProcessHang"`
+	ActionProcessHang bool `yaml:"actionProcessHang"`
 }
 
 // ExpExecutor defines the ExpExecutor interface

--- a/spec/model.go
+++ b/spec/model.go
@@ -68,10 +68,10 @@ type ExpActionCommandSpec interface {
 	// Flags returns the list of flags supported by the action
 	Flags() []ExpFlagSpec
 
-	//Example returns command example
+	// Example returns command example
 	Example() string
 
-	//Example returns command example
+	// Example returns command example
 	SetExample(example string)
 
 	// ExpExecutor returns the action command ExpExecutor

--- a/spec/response.go
+++ b/spec/response.go
@@ -19,8 +19,9 @@ package spec
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 type CodeType struct {
@@ -177,7 +178,7 @@ func Success() *Response {
 	return ReturnSuccess(nil)
 }
 
-//ToString
+// ToString
 func (response *Response) ToString() string {
 	bytes, err := json.MarshalIndent(response, "", "\t")
 	if err != nil {

--- a/util/archive_tar.go
+++ b/util/archive_tar.go
@@ -9,7 +9,6 @@ import (
 )
 
 func ArchiveTar(file string, writer *tar.Writer) error {
-
 	return filepath.Walk(file, func(path string, fileInfo os.FileInfo, err error) error {
 		if fileInfo == nil {
 			return err
@@ -33,7 +32,6 @@ func ArchiveTar(file string, writer *tar.Writer) error {
 			if file, err := os.Open(path); err != nil {
 				return err
 			} else {
-
 				if header, err := tar.FileInfoHeader(fileInfo, ""); err != nil {
 					return err
 				} else {
@@ -49,7 +47,6 @@ func ArchiveTar(file string, writer *tar.Writer) error {
 						return err
 					}
 				}
-
 			}
 			return nil
 		}(file, path, fileInfo, writer)

--- a/util/log.go
+++ b/util/log.go
@@ -82,21 +82,27 @@ func InitLog(programType int) {
 func Panicf(uid, funcName, msg string) {
 	logger(uid, funcName, msg, logrus.PanicLevel)
 }
+
 func Fatalf(uid, funcName, msg string) {
 	logger(uid, funcName, msg, logrus.FatalLevel)
 }
+
 func Errorf(uid, funcName, msg string) {
 	logger(uid, funcName, msg, logrus.ErrorLevel)
 }
+
 func Warnf(uid, funcName, msg string) {
 	logger(uid, funcName, msg, logrus.WarnLevel)
 }
+
 func Infof(uid, funcName, msg string) {
 	logger(uid, funcName, msg, logrus.InfoLevel)
 }
+
 func Debugf(uid, funcName, msg string) {
 	logger(uid, funcName, msg, logrus.DebugLevel)
 }
+
 func Tracef(uid, funcName, msg string) {
 	logger(uid, funcName, msg, logrus.TraceLevel)
 }

--- a/util/signal.go
+++ b/util/signal.go
@@ -17,12 +17,12 @@
 package util
 
 import (
-	"github.com/sirupsen/logrus"
 	"os"
 	"os/signal"
 	"runtime"
 	"syscall"
 
+	"github.com/sirupsen/logrus"
 )
 
 type ShutdownHook interface {

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -94,12 +94,18 @@ func TestParseIntegerListToStringSlice(t *testing.T) {
 		want    []string
 		wantErr bool
 	}{
-		{name: "split by comma", args: args{flagName: "local-port", flagValue: "8080,8081,8082"},
-			want: []string{"8080", "8081", "8082"}},
-		{name: "split by connector", args: args{flagName: "local-port", flagValue: "8080-8083"},
-			want: []string{"8080", "8081", "8082", "8083"}},
-		{name: "split by comma and connector", args: args{flagName: "local-port", flagValue: "7001,8080-8083"},
-			want: []string{"7001", "8080", "8081", "8082", "8083"}},
+		{
+			name: "split by comma", args: args{flagName: "local-port", flagValue: "8080,8081,8082"},
+			want: []string{"8080", "8081", "8082"},
+		},
+		{
+			name: "split by connector", args: args{flagName: "local-port", flagValue: "8080-8083"},
+			want: []string{"8080", "8081", "8082", "8083"},
+		},
+		{
+			name: "split by comma and connector", args: args{flagName: "local-port", flagValue: "7001,8080-8083"},
+			want: []string{"7001", "8080", "8081", "8082", "8083"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/util/spec.go
+++ b/util/spec.go
@@ -28,7 +28,7 @@ import (
 
 // CreateYamlFile converts the spec.Models to spec file
 func CreateYamlFile(models *spec.Models, specFile string) error {
-	file, err := os.OpenFile(specFile, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0755)
+	file, err := os.OpenFile(specFile, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o755)
 	if err != nil {
 		return err
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -35,15 +35,18 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/chaosblade-io/chaosblade-spec-go/log"
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
-	"github.com/sirupsen/logrus"
 )
 
-var proPath string
-var binPath string
-var libPath string
-var yamlPath string
+var (
+	proPath  string
+	binPath  string
+	libPath  string
+	yamlPath string
+)
 
 func init() {
 	rand.Seed(time.Now().UnixNano())


### PR DESCRIPTION
### Does this pull request fix one issue?

RESOLVE https://github.com/chaosblade-io/chaosblade/issues/1200

### Describe how you did it

Introduce `gofumpt` and `goimports` to verify and reformat go codes.
